### PR TITLE
Suppress PHP warnings when loading DomDocument html fetched from the wiki

### DIFF
--- a/public/api/entropia-wiki-events-json-api.php
+++ b/public/api/entropia-wiki-events-json-api.php
@@ -34,7 +34,7 @@ class EntropiaWikiEventsJsonApi
     private static function convertHtmlToDomElement(string $entire_html_content)
     {
         $dom_document = new DOMDocument();
-        $dom_document->loadHTML($entire_html_content);
+        $dom_document->loadHTML($entire_html_content, LIBXML_NOERROR|LIBXML_NOWARNING);
 
         return $dom_document;
     }


### PR DESCRIPTION
…MediaWiki events page (with seems to have partly invalid markup)