### PR TITLE
added hyperlink to spaceall heatmap on status button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
       </div>
 
       <div class="club-status-wrapper">
+        <a href="https://mapall.space/heatmap/show.php?id=Entropia" target="_blank" rel="noopener noreferrer"></a>
         <span class="club-status"></span>
       </div>
 


### PR DESCRIPTION
i added a simple feature wished by some other people. when you click on the status banner, a new tab will be opened with the heatmap from spaceall. the hover for last change feature is still there.