### PR TITLE
Move Code of Conduct link to link list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,6 @@
             <li><a href="https://matrix.to/#/#entropia:entropia.de" title="Matrix-Chat der Gruppe „entropia“ auf dem Server entropia.de">Matrix</a></li>
             <li><a href="https://github.com/entropia" title="Github-Organisationsseite mit Code-Projekten des Vereins">Github</a></li>
             <li><a href="https://entropia.de/Hauptseite" title="Hauptseite des Entropia-Wikis">Wiki</a></li>
-            <li><a href="https://entropia.de/CodeofConduct" title="Code of Conduct des Entropia">CoC</a></li>
           </ul>
         </nav>
       </div>
@@ -340,6 +339,7 @@
               </li>
               <li><a href="https://entropia.de/Satzung" title="Vereinssatzung im Entropia-Wiki">Satzung</a></li>
               <li><a href="https://entropia.de/Policy" title="Liste der Regelwerke des Vereins im Entropia-Wiki">Policy</a></li>
+              <li><a href="https://entropia.de/CodeofConduct" title="Code of Conduct des Entropia">Code of Conduct</a></li>
               <li><a href="https://entropia.de/Handbuch" title="Anleitungen zu Infrastruktur des Vereins im Entropia-Wiki">How To Clubräume</a></li>
             </ul>
           </div>


### PR DESCRIPTION
All links in the header nav that already existed before bdb77da are links to other platforms. The "Code of Conduct" / "CoC" link is the only link to a specific content page. Various content pages with information about the club, its philosophy, policies etc. are already linked in the link list at the bottom of the landing page.