### PR TITLE
increase shown events to 15

### DIFF
--- a/public/api/entropia-wiki-events-json-api.php
+++ b/public/api/entropia-wiki-events-json-api.php
@@ -3,7 +3,7 @@
 class EntropiaWikiEventsJsonApi
 {
     const WIKI_EVENTS_LIST_URL = 'https://entropia.de/Termine';
-    const DEFAULT_MAX_ENTRIES = 10;
+    const DEFAULT_MAX_ENTRIES = 15;
 
     const COLUMN_DATE_INDEX = 0;
     const COLUMN_TIME_INDEX = 1;


### PR DESCRIPTION
We currently have already 10 regularly occurring events, new events like the "Tag des offenenen Hackspaces" are not shown therefore. This change will increase the shown events to the last 15 ones.